### PR TITLE
it seems better to let a property overrule a system-variable for log4…

### DIFF
--- a/src/main/java/io/kahu/hawaii/util/logger/Log4jConfigListener.java
+++ b/src/main/java/io/kahu/hawaii/util/logger/Log4jConfigListener.java
@@ -27,9 +27,9 @@ public class Log4jConfigListener implements ServletContextListener {
 
     @Override
     public void contextInitialized(ServletContextEvent sce) {
-        String config = System.getenv("log4j.configuration");
+        String config = System.getProperty("log4j.configuration");
         if (StringUtils.isBlank(config)) {
-            config = System.getProperty("log4j.configuration");
+            config = System.getenv("log4j.configuration");
         }
         if (StringUtils.isNotEmpty(config)) {
             String overrideConfig = StringUtils.replace(config, ".xml", ".local.xml");


### PR DESCRIPTION
…j. Instead of the other way around. System-properties are often hard-fixed in a pom.xml. Whereas properties often have a local-properties overwrite option